### PR TITLE
feat: Initialize Docsify for ebook website

### DIFF
--- a/_coverpage.md
+++ b/_coverpage.md
@@ -1,0 +1,8 @@
+# Prompt Engineering Ebook
+
+> An extensive guide to the art and science of prompt engineering.
+
+[Get Started](01-introduction/1.1-what-is-prompt-engineering.md)
+
+<!-- background color -->
+![color](#E9F5E9)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,78 @@
+* Introduction
+  * [What is Prompt Engineering?](01-introduction/1.1-what-is-prompt-engineering.md)
+  * [Historical Evolution](01-introduction/1.2-historical-evolution-of-nlp-and-prompts.md)
+  * [Scope and Objectives](01-introduction/1.3-scope-and-objectives-of-prompting.md)
+  * [Common Use Cases](01-introduction/1.4-common-use-cases-success-stories.md)
+  * [Glossary](01-introduction/glossary.md)
+* Foundations of Language Models
+  * [Model Architectures](02-foundations-of-language-models/2.1-model-architectures.md)
+  * [Pretraining vs Fine-tuning](02-foundations-of-language-models/2.2-pretraining-vs-fine-tuning-vs-instruction-tuning.md)
+  * [Tokenization & Embeddings](02-foundations-of-language-models/2.3-tokenization-embeddings-vector-spaces.md)
+  * [Attention & Context Windows](02-foundations-of-language-models/2.4-attention-mechanisms-context-windows.md)
+  * [Glossary](02-foundations-of-language-models/glossary.md)
+* Core Prompting Concepts
+  * [Zero-shot, One-shot, Few-shot](03-core-prompting-concepts/3.1-zero-shot-one-shot-and-few-shot-learning.md)
+  * [Instruction vs Example-based](03-core-prompting-concepts/3.2-instruction-prompts-vs-example-based-prompts.md)
+  * [Framing, Phrasing, Clarity](03-core-prompting-concepts/3.3-prompt-framing-phrasing-and-clarity.md)
+  * [Decoding Controls](03-core-prompting-concepts/3.4-decoding-controls-temperature-top-k-top-p-beam-search.md)
+  * [Glossary](03-core-prompting-concepts/glossary.md)
+* Prompt Design Patterns
+  * [Static Templates & Dynamic Variables](04-prompt-design-patterns/4.1-static-templates-and-dynamic-variables.md)
+  * [Chain-of-Thought](04-prompt-design-patterns/4.2-chain-of-thought-and-step-by-step-reasoning.md)
+  * [Self-Consistency & Ensemble](04-prompt-design-patterns/4.3-self-consistency-voting-and-ensemble-prompts.md)
+  * [Context Management](04-prompt-design-patterns/4.4-context-management-and-window-optimization.md)
+  * [Meta-Prompting](04-prompt-design-patterns/4.5-meta-prompting-and-higher-order-prompts.md)
+  * [Glossary](04-prompt-design-patterns/glossary.md)
+* Advanced Prompt Techniques
+  * [Chaining & Orchestration](05-advanced-prompt-techniques/5.1-prompt-chaining-orchestration-and-pipelines.md)
+  * [Retrieval Augmented Generation](05-advanced-prompt-techniques/5.2-retrieval-augmented-generation-and-memory.md)
+  * [Programmatic Generation & APIs](05-advanced-prompt-techniques/5.3-programmatic-prompt-generation-and-apis.md)
+  * [Prefix Tuning & Adapters](05-advanced-prompt-techniques/5.4-prefix-tuning-adapters-and-soft-prompts.md)
+  * [Debugging & Failure Analysis](05-advanced-prompt-techniques/5.5-debugging-and-prompt-failure-analysis.md)
+  * [Glossary](05-advanced-prompt-techniques/glossary.md)
+* Evaluation and Iteration
+  * [Automated Metrics](06-evaluation-and-iteration/6.1-automated-metrics-bleu-rouge-perplexity-embedding-similarity.md)
+  * [Human Evaluation](06-evaluation-and-iteration/6.2-human-evaluation-criteria-surveys-feedback-loops.md)
+  * [A/B Testing](06-evaluation-and-iteration/6.3-ab-testing-statistical-significance-control-experiments.md)
+  * [Glossary](06-evaluation-and-iteration/glossary.md)
+* Tools, Frameworks, and APIs
+  * [Prompting SDKs](07-tools-frameworks-and-apis/7.1-prompting-sdks-langchain-prompt-toolkit-openai-sdk.md)
+  * [Notebook-based Experimentation](07-tools-frameworks-and-apis/7.2-notebook-based-experimentation.md)
+  * [Logging & Monitoring](07-tools-frameworks-and-apis/7.3-logging-monitoring-and-debugging-tools.md)
+  * [Deployment & Scaling](07-tools-frameworks-and-apis/7.4-deployment-platforms-scaling-and-best-practices.md)
+  * [Glossary](07-tools-frameworks-and-apis/glossary.md)
+* Domain-Specific Applications
+  * [Chatbots & Virtual Assistants](08-domain-specific-applications/8.1-chatbots-and-virtual-assistants.md)
+  * [Summarization & Translation](08-domain-specific-applications/8.2-summarization-and-translation.md)
+  * [Data Extraction & ETL](08-domain-specific-applications/8.3-data-extraction-classification-&-etl.md)
+  * [Education & Tutoring](08-domain-specific-applications/8.4-education-tutoring-systems.md)
+  * [Glossary](08-domain-specific-applications/glossary.md)
+* Security, Robustness, and Adversarial Prompts
+  * [Prompt Injection & Jailbreaks](09-security-robustness-and-adversarial-prompts/9.1-prompt-injection-and-jailbreaks.md)
+  * [Sanitization & Validation](09-security-robustness-and-adversarial-prompts/9.2-sanitization-and-input-validation.md)
+  * [Guardrails & Policy Enforcement](09-security-robustness-and-adversarial-prompts/9.3-guardrails-and-policy-enforcement.md)
+  * [Glossary](09-security-robustness-and-adversarial-prompts/glossary.md)
+* Ethics, Bias, and Responsible Use
+  * [Sources of Bias](10-ethics-bias-and-responsible-use/10.1-sources-of-bias-in-data-and-prompts.md)
+  * [Glossary](10-ethics-bias-and-responsible-use/glossary.md)
+* Scaling and Team Workflows
+  * [Prompt Libraries & Management](11-scaling-and-team-workflows/11.1-prompt-libraries-and-repository-management.md)
+  * [Experiment Tracking & MLOps](11-scaling-and-team-workflows/11.2-experiment-tracking-and-mlops-integration.md)
+  * [Collaboration & Review](11-scaling-and-team-workflows/11.3-collaboration-review-processes-and-code-quality.md)
+  * [CI/CD for Prompt Engineering](11-scaling-and-team-workflows/11.4-ci-cd-for-prompt-engineering.md)
+  * [Glossary](11-scaling-and-team-workflows/glossary.md)
+* Case Studies and Real-World Projects
+  * [Enterprise Deployments](12-case-studies-and-real-world-projects/12.1-enterprise-scale-deployments.md)
+  * [Startups & MVPs](12-case-studies-and-real-world-projects/12.2-startups-and-mvps.md)
+  * [Research & Open Source](12-case-studies-and-real-world-projects/12.3-research-projects-and-open-source-initiatives.md)
+  * [Lessons Learned](12-case-studies-and-real-world-projects/12.4-lessons-learned-and-best-practices.md)
+  * [Glossary](12-case-studies-and-real-world-projects/glossary.md)
+* Future Trends
+  * [Multimodal Prompting](13-future-trends/13.1-multimodal-prompting-text-vision-audio.md)
+  * [Self-Improving Systems](13-future-trends/13.2-self-improving-and-autonomous-systems.md)
+  * [Evolving Role of Engineers](13-future-trends/13.3-the-evolving-role-of-human-engineers.md)
+  * [Glossary](13-future-trends/glossary.md)
+* Appendices
+  * [Prompt Cookbook](14-appendices/14.1-prompt-cookbook-templates-snippets-patterns.md)
+  * [Glossary of Terms](14-appendices/14.2-glossary-of-terms-and-acronyms.md)
+  * [Further Reading](14-appendices/14.3-further-reading-and-resources.md)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Prompt Engineering Ebook</title> <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Prompt Engineering Ebook', // Or use the existing title if appropriate
+      repo: 'https://github.com/USER/REPO', // Replace with the actual repo URL
+      loadSidebar: true,
+      subMaxLevel: 3, // Adjust as needed, 2 or 3 is usually good
+      search: 'auto', // Enables the search plugin
+      coverpage: true, // Add this line
+      plugins: [
+        function(hook, vm) {
+          hook.beforeEach(function(html) {
+            // Replace 'chapters/' with '' in links to make them work correctly
+            // This is because Docsify serves from the root, and we want clean URLs
+            var url = vm.route.file;
+            if (url) {
+              var newPath = url.startsWith('chapters/') ? url.replace('chapters/', '') : url;
+              if (newPath !== url) {
+                vm.route.file = newPath;
+              }
+            }
+            return html;
+          });
+        }
+      ]
+    };
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Transforms the repository into an online ebook using Docsify.

Key changes include:
- Added `index.html` as the Docsify entry point.
- Configured Docsify with a title, repository link, sidebar, search, and cover page.
- Created `_sidebar.md` to generate navigation from the existing chapter structure.
- Added `_coverpage.md` for an attractive landing page.
- Included a `.nojekyll` file for compatibility with GitHub Pages.
- Added a custom Docsify plugin to correctly handle chapter file paths.

The resulting setup allows the Markdown files in the `chapters/` directory to be rendered as an interactive website, deployable on services like GitHub Pages.u