### PR TITLE
fix: Resolve 404 errors by correcting Docsify path resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,23 +16,18 @@
       loadSidebar: true,
       subMaxLevel: 3, // Adjust as needed, 2 or 3 is usually good
       search: 'auto', // Enables the search plugin
-      coverpage: true, // Add this line
-      plugins: [
-        function(hook, vm) {
-          hook.beforeEach(function(html) {
-            // Replace 'chapters/' with '' in links to make them work correctly
-            // This is because Docsify serves from the root, and we want clean URLs
-            var url = vm.route.file;
-            if (url) {
-              var newPath = url.startsWith('chapters/') ? url.replace('chapters/', '') : url;
-              if (newPath !== url) {
-                vm.route.file = newPath;
-              }
-            }
-            return html;
-          });
+      coverpage: true, 
+      resolvePath: function(path) {
+        // If the path is the root README.md, a special Docsify file (starts with '_'),
+        // or an external link, don't modify it.
+        if (path === 'README.md' || path === '/' || path.startsWith('_') || path.startsWith('http')) {
+          return path;
         }
-      ]
+        // For all other paths, assume they are chapter files and prepend 'chapters/'
+        // This ensures that links like '01-introduction/file.md' correctly map to
+        // 'chapters/01-introduction/file.md'.
+        return 'chapters/' + path;
+      }
     };
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
Replaced the previous custom plugin with Docsify's `resolvePath` configuration. This ensures that Markdown files linked from the sidebar and cover page (e.g., `01-introduction/file.md`) are correctly fetched from their actual location within the `chapters/` subdirectory (e.g., `chapters/01-introduction/file.md`).

The `resolvePath` function intelligently prepends `chapters/` to content file paths while leaving special Docsify files (like `_sidebar.md`, `_coverpage.md`) and external links unaffected. This fixes the 404 errors you encountered when trying to render chapter pages.